### PR TITLE
[Bherly] Refactor Consumer to send Metric by AppSecretCollection

### DIFF
--- a/cmds/action.go
+++ b/cmds/action.go
@@ -72,17 +72,16 @@ func ActionBaritoProducerService(c *cli.Context) (err error) {
 
 func callbackInstrumentation() bool {
 	pushMetricUrl := configPushMetricUrl()
-	pushMetricToken := configPushMetricToken()
 	pushMetricInterval := configPushMetricInterval()
 
-	if pushMetricToken == "" || pushMetricUrl == "" {
+	if pushMetricUrl == "" {
 		fmt.Print("No callback for instrumentation")
 		return false
 	}
 
 	instru.SetCallback(
 		timekit.Duration(pushMetricInterval),
-		NewMetricMarketCallback(pushMetricUrl, pushMetricToken),
+		NewMetricMarketCallback(pushMetricUrl),
 	)
 	return true
 

--- a/cmds/config.go
+++ b/cmds/config.go
@@ -15,7 +15,6 @@ const (
 	EnvElasticsearchUrl = "BARITO_ELASTICSEARCH_URL"
 
 	EnvPushMetricUrl      = "BARITO_PUSH_METRIC_URL"
-	EnvPushMetricToken    = "BARITO_PUSH_METRIC_TOKEN"
 	EnvPushMetricInterval = "BARITO_PUSH_METRIC_INTERVAL"
 
 	EnvProducerAddress  = "BARITO_PRODUCER_ADDRESS" // TODO: rename to better name
@@ -39,8 +38,7 @@ var (
 
 	DefaultElasticsearchUrl = "http://localhost:9200"
 
-	DefaultPushMetricUrl      = "http://localhost:3000/api/increase_log_count"
-	DefaultPushMetricToken    = ""
+	DefaultPushMetricUrl      = ""
 	DefaultPushMetricInterval = "30s"
 
 	DefaultProducerAddress  = ":8080"
@@ -86,10 +84,6 @@ func configKafkaGroupId() (s string) {
 
 func configPushMetricUrl() (s string) {
 	return stringEnvOrDefault(EnvPushMetricUrl, DefaultPushMetricUrl)
-}
-
-func configPushMetricToken() (s string) {
-	return stringEnvOrDefault(EnvPushMetricToken, DefaultPushMetricToken)
 }
 
 func configPushMetricInterval() (s string) {

--- a/cmds/config_test.go
+++ b/cmds/config_test.go
@@ -53,14 +53,6 @@ func TestGetPushMetricUrl(t *testing.T) {
 	FatalIf(t, configPushMetricUrl() != "http://some-push-metric", "should get from env variable")
 }
 
-func TestGetPushMetricToken(t *testing.T) {
-	FatalIf(t, configPushMetricToken() != DefaultPushMetricToken, "should return default ")
-
-	os.Setenv(EnvPushMetricToken, "some-token")
-	defer os.Clearenv()
-	FatalIf(t, configPushMetricToken() != "some-token", "should get from env variable")
-}
-
 func TestGetPushMetricInterval(t *testing.T) {
 	FatalIf(t, configPushMetricInterval() != DefaultPushMetricInterval, "should return default ")
 

--- a/cmds/metric_market_callback_test.go
+++ b/cmds/metric_market_callback_test.go
@@ -1,6 +1,7 @@
 package cmds
 
 import (
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
@@ -16,19 +17,20 @@ func TestMetricMarketCallback(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		reqBody, _ = ioutil.ReadAll(r.Body)
 	}))
+	appSecret := "some-secret-1234"
+	instru.Count(fmt.Sprintf("%s_es_store", appSecret)).Event("success")
+	instru.Metric("application_group").Put("app_secrets", []string{"some-secret-1234"})
 
-	instru.Count("es_store").Event("success")
-
-	callback := NewMetricMarketCallback(ts.URL, "token")
+	callback := NewMetricMarketCallback(ts.URL)
 	err := callback.OnCallback(instru.DefaultInstrumentation)
 
 	FatalIfError(t, err)
-	FatalIf(t, string(reqBody) != `{"new_log_count":1,"token":"token"}`, "wrong request body")
+	FatalIf(t, string(reqBody) != `{"application_groups":[{"token":"some-secret-1234","new_log_count":1}]}`, "wrong request body")
 	FatalIf(t, instru.GetEventCount("es_store", "success") != 0, "instrumentation must flushed")
 }
 
 func TestMetricMarketCallback_ClientError(t *testing.T) {
-	callback := NewMetricMarketCallback("wrong-formatted-url", "token")
+	callback := NewMetricMarketCallback("wrong-formatted-url")
 
 	err := callback.OnCallback(instru.DefaultInstrumentation)
 	FatalIfWrongError(t, err, `Post wrong-formatted-url: unsupported protocol scheme ""`)
@@ -39,7 +41,7 @@ func TestMetricMarketCallback_ReturnNotOkStatus(t *testing.T) {
 		w.WriteHeader(http.StatusInternalServerError)
 	}))
 
-	callback := NewMetricMarketCallback(ts.URL, "token")
+	callback := NewMetricMarketCallback(ts.URL)
 	err := callback.OnCallback(instru.DefaultInstrumentation)
 	FatalIfWrongError(t, err, "Got status code 500")
 }

--- a/flow/barito_consumer_service.go
+++ b/flow/barito_consumer_service.go
@@ -67,7 +67,7 @@ func (s *baritoConsumerService) Start() (err error) {
 		return errkit.Concat(ErrMakeKafkaAdmin, err)
 	}
 
-	uuid, _ := uuid.NewV4()
+	uuid := uuid.NewV4()
 	s.eventWorkerGroupID = fmt.Sprintf("%s-%s", PrefixEventGroupID, uuid)
 	log.Infof("Generate event worker group id: %s", s.eventWorkerGroupID)
 

--- a/flow/barito_consumer_service.go
+++ b/flow/barito_consumer_service.go
@@ -67,7 +67,7 @@ func (s *baritoConsumerService) Start() (err error) {
 		return errkit.Concat(ErrMakeKafkaAdmin, err)
 	}
 
-	uuid := uuid.NewV4()
+	uuid, _ := uuid.NewV4()
 	s.eventWorkerGroupID = fmt.Sprintf("%s-%s", PrefixEventGroupID, uuid)
 	log.Infof("Generate event worker group id: %s", s.eventWorkerGroupID)
 

--- a/flow/convert_test.go
+++ b/flow/convert_test.go
@@ -88,15 +88,16 @@ func TestConvertTimberToElasticDocument(t *testing.T) {
 
 func sampleRawTimber() []byte {
 	return []byte(`{
-		"location": "some-location", 
-		"message":"some-message", 
+		"location": "some-location",
+		"message":"some-message",
 		"_ctx": {
 			"kafka_topic": "some_topic",
 			"kafka_partition": 3,
 			"kafka_replication_factor": 1,
 			"es_index_prefix": "some-type",
 			"es_document_type": "some-type",
-			"app_max_tps": 10
+			"app_max_tps": 10,
+			"app_secret": "some-secret-1234"
 		}
 	}`)
 

--- a/flow/elastic.go
+++ b/flow/elastic.go
@@ -24,6 +24,7 @@ func elasticStore(client *elastic.Client, ctx context.Context, timber Timber) (e
 	indexPrefix := timber.Context().ESIndexPrefix
 	documentType := timber.Context().ESDocumentType
 	indexName := fmt.Sprintf("%s-%s", indexPrefix, time.Now().Format("2006.01.02"))
+	appSecret := timber.Context().AppSecret
 
 	exists, _ := client.IndexExists(indexName).Do(ctx)
 
@@ -46,7 +47,7 @@ func elasticStore(client *elastic.Client, ctx context.Context, timber Timber) (e
 		Type(documentType).
 		BodyJson(document).
 		Do(ctx)
-	instruESStore(err)
+	instruESStore(appSecret, err)
 
 	return
 }

--- a/flow/elastic_test.go
+++ b/flow/elastic_test.go
@@ -2,6 +2,7 @@ package flow
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -47,10 +48,12 @@ func TestElasticStore_CreateindexSuccess(t *testing.T) {
 	client, err := elasticNewClient(ts.URL)
 	FatalIfError(t, err)
 
+	appSecret := timber.Context().AppSecret
+
 	err = elasticStore(client, context.Background(), timber)
 	FatalIfError(t, err)
 	FatalIf(t, instru.GetEventCount("es_create_index", "success") != 1, "wrong es_store.total success event")
-	FatalIf(t, instru.GetEventCount("es_store", "success") != 1, "wrong total es_store.success event")
+	FatalIf(t, instru.GetEventCount(fmt.Sprintf("%s_es_store", appSecret), "success") != 1, "wrong total es_store.success event")
 }
 
 func TestElasticStoreman_store_SaveError(t *testing.T) {
@@ -69,7 +72,9 @@ func TestElasticStoreman_store_SaveError(t *testing.T) {
 	client, err := elasticNewClient(ts.URL)
 	FatalIfError(t, err)
 
+	appSecret := timber.Context().AppSecret
+
 	err = elasticStore(client, context.Background(), timber)
 	FatalIfWrongError(t, err, "elastic: Error 400 (Bad Request)")
-	FatalIf(t, instru.GetEventCount("es_store", "fail") != 1, "wrong total fail event")
+	FatalIf(t, instru.GetEventCount(fmt.Sprintf("%s_es_store", appSecret), "fail") != 1, "wrong total fail event")
 }

--- a/flow/instrumentation.go
+++ b/flow/instrumentation.go
@@ -1,6 +1,14 @@
 package flow
 
-import "github.com/BaritoLog/instru"
+import (
+	"fmt"
+
+	"github.com/BaritoLog/instru"
+)
+
+type ApplicationSecretCollection struct {
+	appSecrets []string
+}
 
 func instruESCreateIndex(err error) {
 	if err != nil {
@@ -10,10 +18,40 @@ func instruESCreateIndex(err error) {
 	}
 }
 
-func instruESStore(err error) {
+func instruESStore(appSecret string, err error) {
+	InstruApplicationSecret(appSecret)
+	label := fmt.Sprintf("%s_es_store", appSecret)
 	if err != nil {
-		instru.Count("es_store").Event("fail")
+		instru.Count(label).Event("fail")
 	} else {
-		instru.Count("es_store").Event("success")
+		instru.Count(label).Event("success")
 	}
+}
+
+func Contains(s []string, e string) bool {
+	for _, a := range s {
+		if a == e {
+			return true
+		}
+	}
+	return false
+}
+
+func InstruApplicationSecret(appSecret string) {
+	appSecrets := GetApplicationSecretCollection()
+
+	if !Contains(appSecrets, appSecret) {
+		appSecrets = append(appSecrets, appSecret)
+	}
+
+	instru.Metric("application_group").Put("app_secrets", appSecrets)
+}
+
+func GetApplicationSecretCollection() []string {
+	collection := instru.Metric("application_group").Get("app_secrets")
+	if collection == nil {
+		return []string{}
+	}
+
+	return instru.Metric("application_group").Get("app_secrets").([]string)
 }

--- a/flow/instrumentation_test.go
+++ b/flow/instrumentation_test.go
@@ -1,0 +1,60 @@
+package flow
+
+import (
+	"testing"
+  . "github.com/BaritoLog/go-boilerplate/testkit"
+  "github.com/BaritoLog/instru"
+)
+
+func TestContains_NotMatch(t *testing.T) {
+  given := []string{"a", "b"}
+  exist := Contains(given, "e")
+
+  FatalIf(t, exist, "Should not contain")
+}
+
+func TestContains(t *testing.T) {
+  given := []string{"a", "b"}
+  exist := Contains(given, "b")
+
+  FatalIf(t, !exist, "Should contain")
+}
+
+func TestGetApplicationSecretCollection_Empty(t *testing.T) {
+  want := GetApplicationSecretCollection()
+
+	FatalIf(t, len(want) > 0, "Should be empty")
+}
+
+func TestGetApplicationSecretCollection_Exist(t *testing.T) {
+  expected := []string{"some-secret"}
+  instru.Metric("application_group").Put("app_secrets", expected)
+  want := GetApplicationSecretCollection()
+
+	FatalIf(t, len(want) == 0, "Should not be empty")
+}
+
+// func TestInstruApplicationSecret(t *testing.T) {
+//   appSecret := "some-secret"
+//   InstruApplicationSecret(appSecret)
+//
+//   collection := GetApplicationSecretCollection()
+//   FatalIf(t, !Contains(collection, "some-secret"), "Should contain app secret")
+// }
+
+func TestInstruApplicationSecret(t *testing.T) {
+  appSecret := "some-secret"
+  duplicateAppSecret := "some-secret"
+  nextAppSecret := "other-secret"
+  InstruApplicationSecret(appSecret)
+    collection := GetApplicationSecretCollection()
+    FatalIf(t, !Contains(collection, "some-secret"), "Should contain app secret")
+  InstruApplicationSecret(duplicateAppSecret)
+
+  collection = GetApplicationSecretCollection()
+  FatalIf(t, len(collection) == 2, "Should not be duplicate")
+
+  InstruApplicationSecret(nextAppSecret)
+  collection = GetApplicationSecretCollection()
+  FatalIf(t, len(collection) > 2, "Should be contain 2 app secret")
+}

--- a/flow/timber.go
+++ b/flow/timber.go
@@ -21,6 +21,7 @@ type TimberContext struct {
 	ESIndexPrefix          string `json:"es_index_prefix"`
 	ESDocumentType         string `json:"es_document_type"`
 	AppMaxTPS              int    `json:"app_max_tps"`
+	AppSecret              string `json:"app_secret"`
 }
 
 func NewTimber() Timber {
@@ -100,6 +101,12 @@ func mapToContext(m map[string]interface{}) (ctx *TimberContext, err error) {
 		return
 	}
 
+	appSecret, ok := m["app_secret"].(string)
+	if !ok {
+		err = fmt.Errorf("app_secret is missing")
+		return
+	}
+
 	ctx = &TimberContext{
 		KafkaTopic:             kafkaTopic,
 		KafkaPartition:         int32(kafkaPartition),
@@ -107,6 +114,7 @@ func mapToContext(m map[string]interface{}) (ctx *TimberContext, err error) {
 		ESIndexPrefix:          esIndexPrefix,
 		ESDocumentType:         esDocumentType,
 		AppMaxTPS:              int(appMaxTPS),
+		AppSecret:              appSecret,
 	}
 
 	return

--- a/flow/timber_test.go
+++ b/flow/timber_test.go
@@ -71,5 +71,6 @@ func sampleContextMap() map[string]interface{} {
 		"es_index_prefix":          "some-prefix",
 		"es_document_type":         "some-type",
 		"app_max_tps":              10.0,
+		"app_secret":               "some-secret-1234",
 	}
 }


### PR DESCRIPTION
`AppSecret` need to removed from ENV vars, so Consumer can get `AppSecret` from `Timber` Context. This PR also refactor Metric to be sent by multiple `AppSecret` and send it in 1 batch.