### PR TITLE
fixed : return early on error, before calling any method on nil value

### DIFF
--- a/flow/kafka_admin.go
+++ b/flow/kafka_admin.go
@@ -93,10 +93,11 @@ func (a *kafkaAdmin) CreateTopic(topic string, numPartitions int32, replicationF
 	detail := &sarama.TopicDetail{NumPartitions: numPartitions, ReplicationFactor: replicationFactor}
 	clusterAdmin, err := sarama.NewClusterAdmin(a.brokers, a.client.Config())
 
-	defer clusterAdmin.Close()
 	if err != nil {
 		return
 	}
+
+	defer clusterAdmin.Close()
 
 	err = clusterAdmin.CreateTopic(topic, detail, false)
 	if err != nil {


### PR DESCRIPTION
calling clusterAdmin.Close() before the error check leads to nil value dereference error.
if 
 1. new topic name is provided to producer and  cluster is not reachable.
 2. sarama.NewClusterAdmin() fails