### PR TITLE
enable fallback to local rate limiter in case redis is error

### DIFF
--- a/cmds/action.go
+++ b/cmds/action.go
@@ -1,7 +1,6 @@
 package cmds
 
 import (
-	"context"
 	"fmt"
 	"github.com/go-redis/redis/v8"
 	"time"
@@ -131,10 +130,6 @@ func ActionBaritoProducerService(c *cli.Context) (err error) {
 		Addr:     redisUrl,
 		Password: redisPassword,
 	})
-
-	if err := redisClient.Ping(context.Background()).Err(); err != nil {
-		return err
-	}
 
 	producerParams := map[string]interface{}{
 		"factory":                factory,

--- a/flow/distributed_rate_limiter.go
+++ b/flow/distributed_rate_limiter.go
@@ -95,7 +95,7 @@ func (d *DistributedRateLimiter) IsHitLimit(topic string, count int, maxTokenIfN
 		return true
 	}
 
-	if currentToken >= maxTokenIfNotExist {
+	if (currentToken + int32(count)) >= (maxTokenIfNotExist * int32(d.duration.Seconds())) {
 		log.Debugf("key: %v is reaching limit", key)
 		return true
 	}

--- a/flow/distributed_rate_limiter.go
+++ b/flow/distributed_rate_limiter.go
@@ -95,7 +95,7 @@ func (d *DistributedRateLimiter) IsHitLimit(topic string, count int, maxTokenIfN
 		return true
 	}
 
-	if (currentToken + int32(count)) >= (maxTokenIfNotExist * int32(d.duration.Seconds())) {
+	if (currentToken + int32(count)) > (maxTokenIfNotExist * int32(d.duration.Seconds())) {
 		log.Debugf("key: %v is reaching limit", key)
 		return true
 	}

--- a/flow/distributed_rate_limiter_test.go
+++ b/flow/distributed_rate_limiter_test.go
@@ -13,15 +13,15 @@ import (
 )
 
 const (
-	distributedRateLimiterDefaultTopic    string = "foo"
-	distributedRateLimiterDefaultCount    int    = 2
-	distributedRateLimiterDefaultMaxToken int32  = 3
-	distributedRateLimiterNumOfWorkers    int    = 2
-	// run 3 times more than `distributedRateLimiterDefaultMaxToken` to check is limitation reached
-	distributedRateLimiterDuration time.Duration = time.Second * 2
+	distributedRateLimiterDefaultTopic    string        = "foo"
+	distributedRateLimiterDefaultCount    int           = 2
+	distributedRateLimiterDefaultMaxToken int32         = 3
+	distributedRateLimiterNumOfWorkers    int           = 2
+	distributedRateLimiterDuration        time.Duration = time.Second * 2
 )
 
 var (
+	// run 3 times more than the cap to check is limitation reached
 	distributedRateLimiterNumOfIteration int = 3 + int(distributedRateLimiterDefaultMaxToken)*int(distributedRateLimiterDuration.Seconds())
 )
 

--- a/flow/distributed_rate_limiter_test.go
+++ b/flow/distributed_rate_limiter_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/go-redis/redismock/v8"
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
+	"os"
 	"sync"
 	"testing"
 	"time"
@@ -13,11 +14,15 @@ import (
 
 const (
 	distributedRateLimiterDefaultTopic    string = "foo"
-	distributedRateLimiterDefaultCount    int    = 1
-	distributedRateLimiterDefaultMaxToken int32  = 10
-	distributedRateLimiterNumOfWorkers    int    = 3
+	distributedRateLimiterDefaultCount    int    = 2
+	distributedRateLimiterDefaultMaxToken int32  = 3
+	distributedRateLimiterNumOfWorkers    int    = 2
 	// run 3 times more than `distributedRateLimiterDefaultMaxToken` to check is limitation reached
-	distributedRateLimiterNumOfIteration int = int(distributedRateLimiterDefaultMaxToken) + 3
+	distributedRateLimiterDuration time.Duration = time.Second * 2
+)
+
+var (
+	distributedRateLimiterNumOfIteration int = 3 + int(distributedRateLimiterDefaultMaxToken)*int(distributedRateLimiterDuration.Seconds())
 )
 
 func init() {
@@ -42,8 +47,8 @@ func configureMock(t *testing.T, mock redismock.ClientMock) {
 		mock.ExpectGet(key).SetVal(fmt.Sprintf("%d", i))
 
 		mock.ExpectTxPipeline()
-		mock.ExpectIncrBy(key, 1).RedisNil()
-		mock.ExpectExpire(key, time.Second).RedisNil()
+		mock.ExpectIncrBy(key, int64(distributedRateLimiterDefaultCount)).RedisNil()
+		mock.ExpectExpire(key, distributedRateLimiterDuration).RedisNil()
 		mock.ExpectTxPipelineExec().SetErr(nil)
 	}
 
@@ -54,7 +59,7 @@ func work(t *testing.T, idx int, limiter flow.RateLimiter, iterationCh <-chan in
 	t.Helper()
 	r := require.New(t)
 
-	max := int(distributedRateLimiterDefaultMaxToken)
+	max := int(distributedRateLimiterDefaultMaxToken) * int(distributedRateLimiterDuration.Seconds())
 
 	for i := range iterationCh {
 		key := getKey(t, i)
@@ -66,11 +71,11 @@ func work(t *testing.T, idx int, limiter flow.RateLimiter, iterationCh <-chan in
 
 		log.Debugf("worker-%v got signal for iteration: %v, is reached limit? %v", idx, i, isReachedLimit)
 
-		if i > max && isReachedLimit != true {
+		if i+distributedRateLimiterDefaultCount > max && isReachedLimit != true {
 			r.Equalf(true, isReachedLimit, "at iteration: %v", i)
 		}
 
-		if i < max && isReachedLimit != false {
+		if i+distributedRateLimiterDefaultCount < max && isReachedLimit != false {
 			r.Equalf(false, isReachedLimit, "at iteration: %v", i)
 		}
 
@@ -81,13 +86,14 @@ func work(t *testing.T, idx int, limiter flow.RateLimiter, iterationCh <-chan in
 // TestDistributedRateLimiter_IsHitLimit tests rate limiter with multiple replicas
 // simulated by goroutine
 func TestDistributedRateLimiter_IsHitLimit(t *testing.T) {
+	//db := redis.NewClient(&redis.Options{Addr: "localhost:6379"})
 	db, mock := redismock.NewClientMock()
 	defer db.Close()
 
 	configureMock(t, mock)
 
 	limiter := flow.NewDistributedRateLimiter(db,
-		flow.WithDuration(time.Second),
+		flow.WithDuration(distributedRateLimiterDuration),
 		flow.WithTimeout(time.Second),
 		flow.WithMutex(),
 	)
@@ -102,6 +108,7 @@ func TestDistributedRateLimiter_IsHitLimit(t *testing.T) {
 		close(iterationCh)
 
 		log.Debugf("iteration stucks for %vs, something wrong with the worker / redis", timeout.Seconds())
+		os.Exit(1)
 	}()
 
 	// simulate multiple replicas


### PR DESCRIPTION
Create a fallback to local rate limiter if redis can't be ping-ed

Signed-off-by: clavinjune <24659468+clavinjune@users.noreply.github.com>