### PR TITLE
Improve Distributed Rate Limiter

### DIFF
--- a/flow/distributed_rate_limiter.go
+++ b/flow/distributed_rate_limiter.go
@@ -114,7 +114,7 @@ func (d *DistributedRateLimiter) IsHitLimit(topic string, count int, maxTokenIfN
 		return true
 	}
 
-	if currentToken >= (maxTokenIfNotExist * int32(d.duration.Seconds())) {
+	if currentToken > (maxTokenIfNotExist * int32(d.duration.Seconds())) {
 		log.Debugf("key: %v is reaching limit", key)
 		return true
 	}

--- a/flow/distributed_rate_limiter.go
+++ b/flow/distributed_rate_limiter.go
@@ -237,6 +237,7 @@ func (d *DistributedRateLimiter) onErr(err error) bool {
 	}
 
 	if d.isRedisConnectionRefused(err) {
+		log.Debugf("redis disconnected, start using local limiter")
 		d.isUsingLocal = true
 	}
 

--- a/flow/distributed_rate_limiter_test.go
+++ b/flow/distributed_rate_limiter_test.go
@@ -3,6 +3,7 @@ package flow_test
 import (
 	"fmt"
 	"github.com/BaritoLog/barito-flow/flow"
+	"github.com/go-redis/redis/v8"
 	"github.com/go-redis/redismock/v8"
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
@@ -121,4 +122,85 @@ func TestDistributedRateLimiter_IsHitLimit(t *testing.T) {
 	}
 
 	wg.Wait()
+}
+
+type mockRateLimiter struct {
+	IsStartAttr       bool
+	IsStop            bool
+	IsHitLimitCounter int
+}
+
+func (m *mockRateLimiter) IsHitLimit(topic string, count int, maxTokenIfNotExist int32) bool {
+	m.IsHitLimitCounter++
+	return false
+}
+
+func (m *mockRateLimiter) Start() {
+	m.IsStartAttr = true
+}
+
+func (m *mockRateLimiter) Stop() {
+	m.IsStartAttr = false
+	m.IsStop = true
+}
+
+func (m *mockRateLimiter) IsStart() bool {
+	return m.IsStartAttr
+}
+
+func (m *mockRateLimiter) PutBucket(_ string, _ *flow.LeakyBucket) {
+}
+
+func (m *mockRateLimiter) Bucket(_ string) *flow.LeakyBucket {
+	return nil
+}
+
+func TestDistributedRateLimiter_LocalRateLimiter(t *testing.T) {
+	r := require.New(t)
+
+	// simulate connection refused
+	db := redis.NewClient(&redis.Options{Addr: "[::1]:14045"})
+	mock := &mockRateLimiter{}
+	var localLimiter flow.RateLimiter = mock
+
+	limiter := flow.NewDistributedRateLimiter(db,
+		flow.WithFallbackToLocal(localLimiter),
+	)
+
+	r.Equal(false, limiter.IsStart())
+	r.Equal(false, mock.IsStop)
+
+	limiter.Start()
+	r.Equal(true, limiter.IsStart())
+
+	limiter.Stop()
+	r.Equal(false, limiter.IsStart())
+	r.Equal(true, mock.IsStop)
+}
+
+func TestDistributedRateLimiter_LocalRateLimiter_IsHitLimit(t *testing.T) {
+	r := require.New(t)
+
+	// simulate connection refused
+	db := redis.NewClient(&redis.Options{Addr: "[::1]:14045"})
+	mock := &mockRateLimiter{}
+	var localLimiter flow.Limiter = mock
+
+	limiter := flow.NewDistributedRateLimiter(db,
+		flow.WithFallbackToLocal(localLimiter),
+	)
+
+	r.Equal(0, mock.IsHitLimitCounter)
+
+	isHitLimit := limiter.IsHitLimit("random", 1, 1)
+
+	// first hit will got limit
+	r.Equal(true, isHitLimit)
+	r.Equal(0, mock.IsHitLimitCounter)
+
+	isHitLimit = limiter.IsHitLimit("random", 1, 1)
+
+	// second hit will use local rate limiter
+	r.Equal(false, isHitLimit)
+	r.Equal(1, mock.IsHitLimitCounter)
 }

--- a/flow/distributed_rate_limiter_test.go
+++ b/flow/distributed_rate_limiter_test.go
@@ -45,12 +45,10 @@ func configureMock(t *testing.T, mock redismock.ClientMock) {
 	// redismock limitation: expectation should be set for different topics
 	for i := 1; i <= distributedRateLimiterNumOfIteration; i++ {
 		key := getKey(t, i)
-		mock.ExpectGet(key).SetVal(fmt.Sprintf("%d", i))
 
-		mock.ExpectTxPipeline()
-		mock.ExpectIncrBy(key, int64(distributedRateLimiterDefaultCount)).RedisNil()
+		mock.ExpectIncrBy(key, int64(distributedRateLimiterDefaultCount)).
+			SetVal(int64(i + distributedRateLimiterDefaultCount))
 		mock.ExpectExpire(key, distributedRateLimiterDuration).RedisNil()
-		mock.ExpectTxPipelineExec().SetErr(nil)
 	}
 
 }
@@ -61,6 +59,7 @@ func work(t *testing.T, idx int, limiter flow.RateLimiter, iterationCh <-chan in
 	r := require.New(t)
 
 	max := int(distributedRateLimiterDefaultMaxToken) * int(distributedRateLimiterDuration.Seconds())
+	log.Debug("max:", max)
 
 	for i := range iterationCh {
 		key := getKey(t, i)

--- a/flow/distributed_rate_limiter_test.go
+++ b/flow/distributed_rate_limiter_test.go
@@ -86,7 +86,6 @@ func work(t *testing.T, idx int, limiter flow.RateLimiter, iterationCh <-chan in
 // TestDistributedRateLimiter_IsHitLimit tests rate limiter with multiple replicas
 // simulated by goroutine
 func TestDistributedRateLimiter_IsHitLimit(t *testing.T) {
-	//db := redis.NewClient(&redis.Options{Addr: "localhost:6379"})
 	db, mock := redismock.NewClientMock()
 	defer db.Close()
 

--- a/flow/rate_limiter.go
+++ b/flow/rate_limiter.go
@@ -7,8 +7,18 @@ import (
 	"github.com/BaritoLog/go-boilerplate/timekit"
 )
 
-type RateLimiter interface {
+type Limiter interface {
 	IsHitLimit(topic string, count int, maxTokenIfNotExist int32) bool
+}
+
+type LimiterFunc func(topic string, count int, maxTokenIfNotExist int32) bool
+
+func (fn LimiterFunc) IsHitLimit(topic string, count int, maxTokenIfNotExist int32) bool {
+	return fn(topic, count, maxTokenIfNotExist)
+}
+
+type RateLimiter interface {
+	Limiter
 	Start()
 	Stop()
 	IsStart() bool


### PR DESCRIPTION
- allow fallback to local limiter in the middle of runtime
- remove unused operations
- adjusts unit tests