### PR TITLE
Try to fix missing content when converting timber to es document

### DIFF
--- a/flow/convert.go
+++ b/flow/convert.go
@@ -10,9 +10,10 @@ import (
 )
 
 const (
-	JsonParseError      = errkit.Error("JSON Parse Error")
-	ProtoParseError     = errkit.Error("Protobuf Parse Error")
-	TimberFieldsMissing = errkit.Error("Timber Field Missing Error")
+	JsonParseError       = errkit.Error("JSON Parse Error")
+	ProtoParseError      = errkit.Error("Protobuf Parse Error")
+	TimberContentMissing = errkit.Error("Timber Content Missing Error")
+	TimberFieldsMissing  = errkit.Error("Timber Field Missing Error")
 )
 
 func ConvertTimberToKafkaMessage(timber *pb.Timber, topic string) *sarama.ProducerMessage {
@@ -36,6 +37,10 @@ func ConvertKafkaMessageToTimber(message *sarama.ConsumerMessage) (timber pb.Tim
 
 func ConvertTimberToEsDocumentString(timber pb.Timber, m *jsonpb.Marshaler) (string, error) {
 	doc := timber.GetContent()
+
+	if doc == nil {
+		return "", TimberContentMissing
+	}
 
 	if doc.Fields == nil {
 		return "", TimberFieldsMissing

--- a/flow/convert_test.go
+++ b/flow/convert_test.go
@@ -62,6 +62,17 @@ func TestConvertTimberToEsDocumentString(t *testing.T) {
 	FatalIf(t, expected != document, "expected %s, received %s", expected, document)
 }
 
+func TestConvertTimberToEsDocumentString_ContentIsNil(t *testing.T) {
+	timber := pb.Timber{
+		Content: nil,
+	}
+	document, err := ConvertTimberToEsDocumentString(timber, &jsonpb.Marshaler{})
+	FatalIf(t, TimberContentMissing != err, "expected %s, received %s", TimberContentMissing, document)
+
+	expected := ""
+	FatalIf(t, expected != document, "expected %s, received %s", expected, document)
+}
+
 func TestConvertTimberToEsDocumentString_FieldsIsNil(t *testing.T) {
 	timber := pb.Timber{
 		Content: &structpb.Struct{


### PR DESCRIPTION
This fix introduce guard clause against the missing Content field inside Timber when converting it to ES Document.