### PR TITLE
feat: add log ingestion for redact

### DIFF
--- a/flow/grpc_producer.go
+++ b/flow/grpc_producer.go
@@ -319,6 +319,5 @@ func (s *producerService) handleProduce(timber *pb.Timber, topic string) (err er
 	prome.ObserveByteIngestion(topic, s.topicSuffix, timber)
 
 	prome.IncreaseKafkaMessagesStoredTotal(topic)
-
 	return
 }

--- a/flow/grpc_producer.go
+++ b/flow/grpc_producer.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/BaritoLog/barito-flow/flow/types"
 	"github.com/BaritoLog/barito-flow/prome"
-	"github.com/BaritoLog/barito-flow/redact"
 	"github.com/BaritoLog/go-boilerplate/errkit"
 	"github.com/Shopify/sarama"
 	"github.com/grpc-ecosystem/grpc-gateway/runtime"
@@ -52,7 +51,6 @@ type producerService struct {
 
 	grpcServer   *grpc.Server
 	reverseProxy *http.Server
-	redactor     *redact.Redactor
 }
 
 func NewProducerService(params map[string]interface{}) ProducerService {
@@ -322,10 +320,5 @@ func (s *producerService) handleProduce(timber *pb.Timber, topic string) (err er
 
 	prome.IncreaseKafkaMessagesStoredTotal(topic)
 
-	if s.redactor != nil {
-		for range s.redactor.RulesMap {
-			prome.ObserveRedactByteIngestion(topic, s.topicSuffix, timber)
-		}
-	}
 	return
 }

--- a/prome/prometheus_instrumentation.go
+++ b/prome/prometheus_instrumentation.go
@@ -137,8 +137,8 @@ func InitProducerInstrumentation() {
 	}, []string{"app_name"})
 }
 
-func SetRedactionEnabledTotal(clusterName, appName, ruleType string, count int) {
-	redactionEnabledTotal.WithLabelValues(clusterName, appName, ruleType).Set(float64(count))
+func SetRedactionEnabledTotal(appName, ruleType string, count int) {
+	redactionEnabledTotal.WithLabelValues(appName, ruleType).Set(float64(count))
 }
 
 func IncreaseConsumerTimberConvertError(index string) {

--- a/prome/prometheus_instrumentation.go
+++ b/prome/prometheus_instrumentation.go
@@ -38,7 +38,7 @@ var producerSendToKafkaTimeSecond *prometheus.SummaryVec
 var producerKafkaClientFailed *prometheus.CounterVec
 var producerTotalLogBytesIngested *prometheus.CounterVec
 var producerTPSExceededLogBytes *prometheus.CounterVec
-var redactProducerTotalLogBytesIngested *prometheus.CounterVec
+var producerRedactTotalLogBytesIngested *prometheus.CounterVec
 
 var redactionEnabledTotal *prometheus.GaugeVec
 
@@ -131,7 +131,7 @@ func InitProducerInstrumentation() {
 		Name: "barito_producer_tps_exceeded_log_bytes",
 		Help: "Log bytes of TPS exceeded requests",
 	}, []string{"app_name"})
-	redactProducerTotalLogBytesIngested = promauto.NewCounterVec(prometheus.CounterOpts{
+	producerRedactTotalLogBytesIngested = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name: "barito_producer_redact_produced_total_log_bytes",
 		Help: "Total log bytes being ingested by the producer that redacted enabled",
 	}, []string{"app_name"})
@@ -152,11 +152,8 @@ func ObserveByteIngestion(topic string, suffix string, timber *pb.Timber) {
 	producerTotalLogBytesIngested.WithLabelValues(appName).Add(math.Round(float64(len(b))))
 }
 
-func ObserveRedactByteIngestion(topic string, suffix string, timber *pb.Timber) {
-	re := regexp.MustCompile(suffix + "$")
-	appName := re.ReplaceAllString(topic, "")
-	b, _ := proto.Marshal(timber)
-	redactProducerTotalLogBytesIngested.WithLabelValues(appName).Add(math.Round(float64(len(b))))
+func ObserveRedactByteIngestion(appName string, doc string) {
+	producerRedactTotalLogBytesIngested.WithLabelValues(appName).Add(math.Round(float64(len(doc))))
 }
 
 func ObserveTPSExceededBytes(topic string, suffix string, timber *pb.Timber) {

--- a/prome/prometheus_instrumentation.go
+++ b/prome/prometheus_instrumentation.go
@@ -137,8 +137,8 @@ func InitProducerInstrumentation() {
 	}, []string{"app_name"})
 }
 
-func SetRedactionEnabledTotal(appName, ruleType string, count int) {
-	redactionEnabledTotal.WithLabelValues(appName, ruleType).Set(float64(count))
+func SetRedactionEnabledTotal(clusterName, appName, ruleType string, count int) {
+	redactionEnabledTotal.WithLabelValues(clusterName, appName, ruleType).Set(float64(count))
 }
 
 func IncreaseConsumerTimberConvertError(index string) {

--- a/redact/redactor.go
+++ b/redact/redactor.go
@@ -103,10 +103,10 @@ func fetchRulesMapFromMarket(marketEndpoint, clusterName, marketClientKey string
 
 	for appName, rules := range rulesMap {
 		staticRulesCount := len(rules.StaticRules)
-		prome.SetRedactionEnabledTotal(clusterName, appName, "StaticRules", staticRulesCount)
+		prome.SetRedactionEnabledTotal(appName, "StaticRules", staticRulesCount)
 
 		jsonPathRulesCount := len(rules.JsonPathRules)
-		prome.SetRedactionEnabledTotal(clusterName, appName, "JsonPathRules", jsonPathRulesCount)
+		prome.SetRedactionEnabledTotal(appName, "JsonPathRules", jsonPathRulesCount)
 	}
 
 	return rulesMap, nil

--- a/redact/redactor.go
+++ b/redact/redactor.go
@@ -102,10 +102,10 @@ func fetchRulesMapFromMarket(marketEndpoint, clusterName, marketClientKey string
 
 	for appName, rules := range rulesMap {
 		staticRulesCount := len(rules.StaticRules)
-		prome.SetRedactionEnabledTotal(appName, "StaticRules", staticRulesCount)
+		prome.SetRedactionEnabledTotal(clusterName, appName, "StaticRules", staticRulesCount)
 
 		jsonPathRulesCount := len(rules.JsonPathRules)
-		prome.SetRedactionEnabledTotal(appName, "JsonPathRules", jsonPathRulesCount)
+		prome.SetRedactionEnabledTotal(clusterName, appName, "JsonPathRules", jsonPathRulesCount)
 	}
 
 	return rulesMap, nil

--- a/redact/redactor.go
+++ b/redact/redactor.go
@@ -102,10 +102,10 @@ func fetchRulesMapFromMarket(marketEndpoint, clusterName, marketClientKey string
 
 	for appName, rules := range rulesMap {
 		staticRulesCount := len(rules.StaticRules)
-		prome.SetRedactionEnabledTotal(clusterName, appName, "StaticRules", staticRulesCount)
+		prome.SetRedactionEnabledTotal(appName, "StaticRules", staticRulesCount)
 
 		jsonPathRulesCount := len(rules.JsonPathRules)
-		prome.SetRedactionEnabledTotal(clusterName, appName, "JsonPathRules", jsonPathRulesCount)
+		prome.SetRedactionEnabledTotal(appName, "JsonPathRules", jsonPathRulesCount)
 	}
 
 	return rulesMap, nil

--- a/redact/redactor.go
+++ b/redact/redactor.go
@@ -24,6 +24,7 @@ func (r *Redactor) Redact(appName, doc string) (redactedDoc string, err error) {
 	}
 
 	rules := r.RulesMap["default"]
+	prome.ObserveRedactByteIngestion(appName, doc)
 	return rules.Redact(doc), nil
 }
 


### PR DESCRIPTION
- delete the `clustername` label for `barito_redaction_status` , because have duplicate with label `app_group`
   `barito_redaction_status{app_group="raba", app_name="abc", cloud="gcp", cluster_name="s-go-gb-primary-gke-01", clustername="raba",`
- add producer log ingestion for appgroup that redaction status = `ENABLED`